### PR TITLE
rebuild every week to ensure build copy is avaliable

### DIFF
--- a/.github/workflows/makefile.yml
+++ b/.github/workflows/makefile.yml
@@ -5,6 +5,8 @@ on:
     branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
+  schedule:
+    - cron: "0 0 * * 0"
 
 jobs:
   build-libusb-linux:


### PR DESCRIPTION
Scripts like https://github.com/verygenericname/SSHRD_Script use nightly.link, which checks for a copy of `gaster-"$oscheck".zip` from the build. If no build is there because its expired, then users cannot continue. 

To ensure the script is working longterm, build every week.